### PR TITLE
Fix liquibase always runs when starting the app

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,6 @@ spring.datasource.url=jdbc:oracle:thin:@localhost:49171:XE
 spring.datasource.username=system
 spring.datasource.password=oracle
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.Oracle12cDialect
-spring.liquibase.drop-first=true
 # create database schema from SQL files
 spring.jpa.hibernate.ddl-auto=none
 logging.level.root=INFO


### PR DESCRIPTION
In the past, the key "drop-first" is "true" makes liquibase drop table databasechangelog when the app starting. Then all changesets will be run again.